### PR TITLE
Infrastructure Basics: Container Registry and Dockerfile

### DIFF
--- a/infra/basics/.terraform.lock.hcl
+++ b/infra/basics/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.69.0"
+  constraints = "2.69.0"
+  hashes = [
+    "h1:DxBvaDJDg5nhQ0L75saAo5c6uH9yz83TX0xuy+QXNs4=",
+    "zh:0b73236a7505a4cfdf804e66091a04e46d60df11d508bc505c91efe3f4ccfa0d",
+    "zh:2ace6cbcb7d7c97fa2100d02c05bb851116c25ed32892297c7fc8085437fa065",
+    "zh:3aa0d0a6e89406122b1869103eb3a48bf295d5ac0be020e2bf5c465c9fc82316",
+    "zh:5019e39d14596041bdb6f75f1e22bf1b4f4443fbe6796571de574f990fcb78bd",
+    "zh:732d9af72c74dc5dba785c4277918fcf1ce68702ee6be47b0734959cfee2187e",
+    "zh:9bdb5fdf6d224178a5d424b9a275e8d9b4d91abd461e1510ff6653fbc98b5cc7",
+    "zh:a4a1c5206088f0941dc6e654ce56f533a441dd403a9eb31179fcc308b04f76f1",
+    "zh:ccae0d045a76ae025bcb624864a824be01a7cf5b69945083bec621691b12f9ad",
+    "zh:dcc5a182c26b4414501a9f3a5b3cb0f8da59250c6f1f45aae9feef634a02b23b",
+    "zh:f0ffcf51dd1a2592fb3aeb29fe5b181f9fa2c7d7e8c2f9ef3a03868f4776e24c",
+    "zh:fea981e0a852ccda2225b0731446346c201a951027743634257191f926f8c197",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/infra/basics/main.tf
+++ b/infra/basics/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.69.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "random_string" "random" {
+  length  = 5
+  special = false
+  number  = true
+  lower   = true
+  upper   = false
+}
+
+locals {
+  name_prefix = "${var.prefix}${random_string.random.result}"
+  required_tags = {
+    environment = var.environment
+  }
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.name_prefix}-${var.environment}-rg"
+  location = var.location
+  tags     = local.required_tags
+}
+
+resource "azurerm_container_registry" "acr" {
+  name                = "${local.name_prefix}acr"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = var.container_registry_sku
+  admin_enabled       = false
+  tags                = local.required_tags
+}
+
+resource "azurerm_role_assignment" "acr_role" {
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = "acrpull"
+  principal_id         = var.service_principal_objectid
+}

--- a/infra/basics/outputs.tf
+++ b/infra/basics/outputs.tf
@@ -1,0 +1,3 @@
+output "acr_login_server" {
+  value = azurerm_container_registry.acr.login_server
+}

--- a/infra/basics/principal.sh
+++ b/infra/basics/principal.sh
@@ -1,0 +1,13 @@
+spName=lis-project-acr
+
+# Create a service principal and get password
+spPassword=$(az ad sp create-for-rbac --name $spName --query password --output tsv)
+# Get service principal application id
+spAppId=$(az ad sp list --display-name $spName --query [].appId --output tsv)
+# Get service principal object id
+spObjectId=$(az ad sp list --display-name $spName --query [].objectId --output tsv)
+
+echo "name: $spName"
+echo "appId: $spAppId"
+echo "objectId: $spObjectId"
+echo "password: $spPassword"

--- a/infra/basics/variables.tf
+++ b/infra/basics/variables.tf
@@ -1,0 +1,25 @@
+variable "prefix" {
+  description = "The prefix name used to create all resources."
+  type        = string
+  default     = "lis"
+}
+variable "location" {
+  description = "The location of all resources."
+  type        = string
+  default     = "westeurope"
+}
+variable "environment" {
+  description = "Environment flag, used in resource group name and resource tags."
+  type        = string
+  default     = "dev"
+}
+variable "service_principal_objectid" {
+  description = "Service principal object id."
+  type        = string
+  sensitive   = true
+}
+variable "container_registry_sku" {
+  description = "Azure container registry sku."
+  type        = string
+  default     = "Basic"
+}

--- a/nlp/Dockerfile
+++ b/nlp/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get install -y python3 python3-pip
+
+RUN mkdir /app
+WORKDIR /app
+
+ADD requirements.txt /app
+ADD main.py /app
+
+RUN pip3 install -r requirements.txt
+EXPOSE 8000
+
+CMD ["gunicorn", "-w 2", "-b", "0.0.0.0:8000", "main:app"]

--- a/nlp/main.py
+++ b/nlp/main.py
@@ -1,0 +1,7 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/")
+def hello():
+    return "Hello, World!"

--- a/nlp/requirements.txt
+++ b/nlp/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+gunicorn


### PR DESCRIPTION
# PR Summary:

- Adding a bash script (`principal.sh`) to create a service principal used to pull images from registry to container instances. Managed identities are not available in this scenario, this is a limitation of container instances. (cf. [How to use managed identities with Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-managed-identity)

> You can't use a managed identity to pull an image from Azure Container Registry when creating a container group. The identity is only available within a running container.

- Adding Terraform files to create container registry and service principal assignment with acrpull role.
- Adding Dockerfile to build container image using Flask and gunicorn. Will be enhanced with tensorflow and code to invoke a pretrained model.

